### PR TITLE
Improve async snapshot function

### DIFF
--- a/src/main/java/cn/magicalsheep/csunoticeapi/service/impl/http/CSEHttpService.java
+++ b/src/main/java/cn/magicalsheep/csunoticeapi/service/impl/http/CSEHttpService.java
@@ -13,6 +13,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.openqa.selenium.WebDriver;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -71,6 +72,9 @@ public class CSEHttpService extends BaseHttpService {
 
     @Override
     protected String fetchContent(Notice notice) {
-        return HttpUtils.snapshot(notice.getUri());
+        WebDriver driver = HttpUtils.createDriver();
+        String ret = HttpUtils.snapshot(driver, notice.getUri());
+        driver.quit();
+        return ret;
     }
 }

--- a/src/main/java/cn/magicalsheep/csunoticeapi/service/impl/http/SchoolHttpService.java
+++ b/src/main/java/cn/magicalsheep/csunoticeapi/service/impl/http/SchoolHttpService.java
@@ -14,6 +14,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.openqa.selenium.WebDriver;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,9 +28,9 @@ public class SchoolHttpService extends BaseHttpService {
         super(schoolStoreService, NoticeType.SCHOOL);
     }
 
-    private boolean loginByBrowser(String user, String pwd) {
+    private boolean loginByBrowser(WebDriver driver, String user, String pwd) {
         LoginPacket loginPacket = new LoginPacket(user, pwd);
-        String html = HttpUtils.getByBrowser(HttpUtils.getURI(Factory.getConfiguration().getRoot_uri() + "/Home/PostLogin", loginPacket));
+        String html = HttpUtils.getByBrowser(driver, HttpUtils.getURI(Factory.getConfiguration().getRoot_uri() + "/Home/PostLogin", loginPacket));
         return html.contains("1");
     }
 
@@ -83,12 +84,15 @@ public class SchoolHttpService extends BaseHttpService {
 
     @Override
     protected String fetchContent(Notice notice) {
-        String checkHtml = HttpUtils.getByBrowser(HttpUtils.getURI(notice.getUri()));
+        WebDriver driver = HttpUtils.createDriver();
+        String checkHtml = HttpUtils.getByBrowser(driver, HttpUtils.getURI(notice.getUri()));
         if (!checkHtml.contains(notice.getTitle())) {
-            if (!loginByBrowser(
+            if (!loginByBrowser(driver,
                     Factory.getConfiguration().getUser(), Factory.getConfiguration().getPwd()))
                 return null;
         }
-        return HttpUtils.snapshot(notice.getUri());
+        String ret = HttpUtils.snapshot(driver, notice.getUri());
+        driver.quit();
+        return ret;
     }
 }


### PR DESCRIPTION
Remove build-in WebDriver instance. Create a new WebDriver instance when getting snapshot and destroy it after using. NOT TESTING YET